### PR TITLE
refactor: split proto load and socket listed into different promises

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge-js",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -67,12 +67,6 @@
       "version": "8.0.57",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.57.tgz",
       "integrity": "sha512-ZxrhcBxlZA7tn0HFf7ebUYfR9aHyBgjyavBLzyrYMYuAMbONBPY4S5O35562iV2FfwnZCjQky3gTDy1B3jSZ2Q=="
-    },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
-      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -253,6 +247,15 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
+    },
+    "check-if-windows": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/check-if-windows/-/check-if-windows-1.0.0.tgz",
+      "integrity": "sha1-xKhkjtoPiS1hQhvr2ROjwpV51Lg=",
+      "dev": true,
+      "requires": {
+        "utils-platform": "1.0.0"
+      }
     },
     "cli": {
       "version": "1.0.1",
@@ -995,6 +998,12 @@
         "nomnom": "1.8.1"
       }
     },
+    "JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
+      "dev": true
+    },
     "just-extend": {
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
@@ -1667,11 +1676,22 @@
         }
       }
     },
+    "utils-platform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-platform/-/utils-platform-1.0.0.tgz",
+      "integrity": "sha1-WV6sl6P2jZs29JMrKU/CJpdFE7A=",
+      "dev": true
+    },
     "uuid": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
       "dev": true
+    },
+    "valid-identifier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/valid-identifier/-/valid-identifier-0.0.1.tgz",
+      "integrity": "sha1-7x1wk6nTKH4/zpLfkW+GFrI/kLQ="
     },
     "vow": {
       "version": "0.4.17",

--- a/src/connection.js
+++ b/src/connection.js
@@ -19,7 +19,8 @@ var ExecutionConnection = function (host, port, message) {
 
   var errorHandler = function (err) {
     self.emit("socketError", err);
-  }
+  };
+  
   this.writeMessage = function(response) {
     self.socket.write(self.message.encodeDelimited(self.message.create(response)).finish());
   };

--- a/src/connection.js
+++ b/src/connection.js
@@ -17,11 +17,15 @@ var ExecutionConnection = function (host, port, message) {
     self.emit("messageReceived", self.message.decodeDelimited(bytes));
   };
 
+  var errorHandler = function (err) {
+    self.emit("socketError", err);
+  }
   this.writeMessage = function(response) {
     self.socket.write(self.message.encodeDelimited(self.message.create(response)).finish());
   };
 
   this.socket.on("data", messageHandler);
+  this.socket.on("error", errorHandler);
 };
 
 util.inherits(ExecutionConnection, EventEmitter);

--- a/src/gauge.js
+++ b/src/gauge.js
@@ -11,25 +11,31 @@ function run() {
   protobuf.load(path.resolve("gauge-proto/messages.proto")).then(function (root) {
     var message = root.lookupType("gauge.messages.Message");
     var errorType = root.lookupEnum("gauge.messages.StepValidateResponse.ErrorType");
-
-    var gaugeInternalConnection = new Connection("localhost", GAUGE_INTERNAL_PORT, message);
+    return {message: message, errorType: errorType}
+  }).catch(function (e) {
+    console.error("Failed while loading runner.\n", e);
+    process.exit();
+  }).then(function(types){
+    var gaugeInternalConnection = new Connection("localhost", GAUGE_INTERNAL_PORT, types.message);
     gaugeInternalConnection.run();
 
     loader.load(GAUGE_PROJECT_ROOT);
 
-    var processor = new MessageProcessor({ message: message, errorType: errorType });
+    var processor = new MessageProcessor(types);
 
     gaugeInternalConnection.on("messageReceived", function (decodedData) {
       processor.getResponseFor(decodedData);
     });
 
+    gaugeInternalConnection.on("socketError", function (err) {
+      throw err;
+    });
+
     processor.on("messageProcessed", function (response) {
       gaugeInternalConnection.writeMessage(response);
     });
-
-  }).catch(function (e) {
-    console.error("Failed while loading runner.\n", e);
-    process.exit();
+  }).catch(function(e){
+    console.error(e);
   });
 }
 

--- a/src/gauge.js
+++ b/src/gauge.js
@@ -11,7 +11,7 @@ function run() {
   protobuf.load(path.resolve("gauge-proto/messages.proto")).then(function (root) {
     var message = root.lookupType("gauge.messages.Message");
     var errorType = root.lookupEnum("gauge.messages.StepValidateResponse.ErrorType");
-    return {message: message, errorType: errorType}
+    return {message: message, errorType: errorType};
   }).catch(function (e) {
     console.error("Failed while loading runner.\n", e);
     process.exit();


### PR DESCRIPTION
splitting the protobuf load promise 

- proto load errror can lead to `process.exit`
- socket error does not kill the runner, helps log the error better.
