### PR TITLE
Expose standard node.js globals in sandbox

### DIFF
--- a/src/vm.js
+++ b/src/vm.js
@@ -36,10 +36,12 @@ VM.prototype.contextify = function (filePath, root) {
     process: process,
     gauge: gaugeGlobal.gauge,
     step: gaugeGlobal.step,
-    setTimeout: setTimeout,
+    setImmediate: setImmediate,
     setInterval: setInterval,
-    clearTimeout: clearTimeout,
+    setTimeout: setTimeout,
+    clearImmediate: clearImmediate,
     clearInterval: clearInterval,
+    clearTimeout: clearTimeout,
     gauge_runner_root: process.cwd(),
     gauge_project_root: self.options.root
   };

--- a/src/vm.js
+++ b/src/vm.js
@@ -28,6 +28,8 @@ VM.prototype.contextify = function (filePath, root) {
   var sandbox = {
     isVM: true,
     console: console,
+    __dirname: path.dirname(path.resolve(filePath)),
+    __filename: path.resolve(filePath),
     require: self.require.fn,
     module: self.require.mod,
     exports: self.require.exports,

--- a/test/vm-test.js
+++ b/test/vm-test.js
@@ -108,6 +108,18 @@ describe("VM", function () {
         assert.doesNotThrow(function () { vm.run(type + "(function(){})"); });
       });
     });
+
+    it("setImmediate", function () {
+      var vm = new VM();
+      vm.contextify();
+      assert.doesNotThrow(function () { vm.run("setImmediate(function () {})"); });
+    });
+
+    it("clearImmediate", function () {
+      var vm = new VM();
+      vm.contextify();
+      assert.doesNotThrow(function () { vm.run("clearImmediate()"); });
+    });
   });
 
   it("should not read from file and run code", function () {

--- a/test/vm-test.js
+++ b/test/vm-test.js
@@ -49,6 +49,34 @@ describe("VM", function () {
       assert.doesNotThrow(function () { vm.run("var ohai = gauge.step"); });
     });
 
+    it("__dirname", function () {
+      var vm = new VM();
+      vm.contextify(path.join("/", "some", "file.js"));
+      assert.doesNotThrow(function () {
+        vm.run(`
+          var path = require('path');
+          var expected = path.join('/', 'some');
+          if (__dirname !== expected) {
+            throw new Error('__dirname "' + __dirname + '" did not match "' + expected + '"');
+          }
+        `);
+      });
+    });
+
+    it("__filename", function () {
+      var vm = new VM();
+      vm.contextify(path.join("/", "some", "file.js"));
+      assert.doesNotThrow(function () {
+        vm.run(`
+          var path = require('path');
+          var expected = path.join('/', 'some', 'file.js');
+          if (__filename !== expected) {
+            throw new Error('__filename "' + __filename + '" did not match "' + expected + '"');
+          }
+        `);
+      });
+    });
+
     it("require", function () {
       var vm = new VM();
       vm.contextify();


### PR DESCRIPTION
Closes #132.

I was a bit confused by the usage of `options.filepath` and `options.dirname` in `src/vm.js` since the options aren't used by `vm.runInContext`, so please review to make sure the changes behave as expected.

I haven't tested this on Windows machines but I used `path.join` hoping that the tests would pass across platforms.