### PR TITLE
make node runtime and args configurable, #168

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ if(process.argv[2] === "--init") {
 else if(process.argv[2] === "--start") {
   var args = ["./src/gauge.js", "--run"];
   if(process.env.gauge_nodejs_args) {
-    args = process.env.gauge_nodejs_args.split(' ').concat(args);
+    args = process.env.gauge_nodejs_args.split(" ").concat(args);
   }
   var cmd = process.env.gauge_nodejs_bin || "node";
   var runner = child_process.spawn(cmd, args, { env: process.env, silent: false, stdio: "inherit" });

--- a/index.js
+++ b/index.js
@@ -39,7 +39,10 @@ if(process.argv[2] === "--init") {
 
 else if(process.argv[2] === "--start") {
   var args = ["./src/gauge.js", "--run"];
-  var cmd = "node";
+  if(process.env.gauge_nodejs_args) {
+    args = process.env.gauge_nodejs_args.split(' ').concat(args);
+  }
+  var cmd = process.env.gauge_nodejs_bin || "node";
   var runner = child_process.spawn(cmd, args, { env: process.env, silent: false, stdio: "inherit" });
   runner.on("error", function (err) {
     console.trace(err.stack);


### PR DESCRIPTION
configure `node` runtime and arguments via below properties:

- `gauge_nodejs_bin` - defaults to `node`
- `gauge_nodejs_args` - optional

