### PR TITLE
fix(req-manager): fix the regular require of js files

### DIFF
--- a/src/req-manager.js
+++ b/src/req-manager.js
@@ -36,10 +36,10 @@ Req.prototype.load = function (modname) {
         return m.require(modname);
       }
       let relativePath = path.join(path.dirname(self.filepath), modname);
-      if (fs.existsSync(relativePath)) {
-        return m.require(relativePath);
+      if (!fs.existsSync(relativePath)) {
+        return m.require(modname);
       }
-      return m.require(modname);
+      return m.require(relativePath);
     } catch (e) {
       logger.error("Unable to require module '" + modname + "' in " + self.filepath + "\n" + e.stack);
       return null;


### PR DESCRIPTION
**Description of changes made**
 The regular `require` statements got broken in gauge-js plugin v2.3.6.

I have a `step_implementation.js` that has the require statements as below:
```
const x = require('url');
const y = require("@scope/package-name");
const z = require("../../lib/example"); // Note: example is a .js file (example.js) and not a directory
```
For x and y case, the check fs.existsSync(relativePath) works fine but for z case , the same check breaks because it assumes that example is a directory and not a .js file and because of this I started to get the error ` Unable to require module '../../lib/example'` for z cases.

fixes #271 
