### PR TITLE
Use grpc protoloader instead of grpc's load method

### DIFF
--- a/offline-package.json
+++ b/offline-package.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge-js",
-  "version": "2.3.6",
+  "version": "2.3.8",
   "description": "JavaScript runner for Gauge",
   "main": "index.js",
   "config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,15 @@
         }
       }
     },
+    "@grpc/proto-loader": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.3.tgz",
+      "integrity": "sha512-8qvUtGg77G2ZT2HqdqYoM/OY97gQd/0crSG34xNmZ4ZOsv3aQT/FQV9QfZPazTGna6MIoyUd+u6AxsoZjJ/VMQ==",
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "protobufjs": "^6.8.6"
+      }
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/getgauge/gauge-js",
   "dependencies": {
+    "@grpc/proto-loader": "^0.5.3",
     "console-stamp": "^0.2.9",
     "escodegen": "^1.12.1",
     "esprima": "^4.0.1",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -84,6 +84,7 @@ var prepareFiles = function (buildOffLinePakcage) {
   }
   if( buildOffLinePakcage) {
     fs.copyFileSync(path.resolve("./package-backup.json"), path.resolve("./package.json"));
+    fs.removeSync(path.resolve("./package-backup.json"));
   }
 };
 

--- a/src/gauge.js
+++ b/src/gauge.js
@@ -12,8 +12,18 @@ if (config.hasPureJsGrpc) {
   servicesProto = grpc.loadPackageDefinition(packageDefinition).gauge.messages;
 } else {
   grpc = require("grpc");
-  servicesProto = grpc.load(PROTO_PATH).gauge.messages;
+  const protoLoader = require("@grpc/proto-loader");
+  // These options approximates the existing behavior of grpc.load
+  const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true
+  });
+  servicesProto = grpc.loadPackageDefinition(packageDefinition).gauge.messages;
 }
+
 var ServiceHandlers = require("./serviceHandlers");
 var logger = require("./logger");
 

--- a/src/gauge.js
+++ b/src/gauge.js
@@ -1,28 +1,28 @@
 var gaugeGlobal = require("./gauge-global");
 var protobuf = require("protobufjs");
+const protoLoader = require("@grpc/proto-loader");
 var path = require("path");
 var loader = require("./static-loader");
 var PROTO_PATH = __dirname + "/../gauge-proto/services.proto";
-var grpc, servicesProto;
+var grpc;
 var config = require("../package.json").config || {};
+
+
 if (config.hasPureJsGrpc) {
   grpc = require("@grpc/grpc-js");
-  const protoLoader = require("@grpc/proto-loader");
-  const packageDefinition = protoLoader.loadSync(PROTO_PATH);
-  servicesProto = grpc.loadPackageDefinition(packageDefinition).gauge.messages;
 } else {
   grpc = require("grpc");
-  const protoLoader = require("@grpc/proto-loader");
-  // These options approximates the existing behavior of grpc.load
-  const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
-    keepCase: true,
-    longs: String,
-    enums: String,
-    defaults: true,
-    oneofs: true
-  });
-  servicesProto = grpc.loadPackageDefinition(packageDefinition).gauge.messages;
 }
+// These options approximates the existing behavior of grpc.load
+const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true
+});
+
+const servicesProto = grpc.loadPackageDefinition(packageDefinition).gauge.messages;
 
 var ServiceHandlers = require("./serviceHandlers");
 var logger = require("./logger");


### PR DESCRIPTION
This fixes the message

DeprecationWarning: grpc.load: Use the @grpc/proto-loader module with grpc.loadPackageDefinition instead

Refer https://github.com/getgauge/taiko/issues/413