### PR TITLE
[Docs] Fix description for afterSuite

### DIFF
--- a/docs/syntax/execution-hooks.md
+++ b/docs/syntax/execution-hooks.md
@@ -11,7 +11,7 @@ gauge-js supports tagged [execution hooks](http://getgauge.io/documentation/user
 
 **"After" hooks:**
 
-- **`gauge.hooks.afterSuite(fn, [opts]) { ... }`** - Executed after the test suite begins
+- **`gauge.hooks.afterSuite(fn, [opts]) { ... }`** - Executed after the test suite ends
 - **`gauge.hooks.afterSpec(fn, [opts]) { ... }`** - Executed after each specification
 - **`gauge.hooks.afterScenario(fn, [opts]) { ... }`** - Executed after each scenario
 - **`gauge.hooks.afterStep(fn, [opts]) { ... }`**- Execute after each step


### PR DESCRIPTION
I found that the hook runs after the suite ends, not begins.