### PR TITLE
Add entries method for looping through table rows

### DIFF
--- a/js.json
+++ b/js.json
@@ -51,7 +51,7 @@
             "--init"
         ]
     },
-    "version": "2.3.14",
+    "version": "2.3.15",
     "gaugeVersionSupport": {
         "minimum": "1.0.7",
         "maximum": ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge-js",
-  "version": "2.3.14",
+  "version": "2.3.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge-js",
-  "version": "2.3.14",
+  "version": "2.3.15",
   "description": "JavaScript runner for Gauge",
   "main": "index.js",
   "scripts": {

--- a/src/executor.js
+++ b/src/executor.js
@@ -1,4 +1,5 @@
 var Q = require("q");
+var Table = require("./table");
 
 var factory = require("./response-factory"),
   Test = require("./test"),
@@ -44,8 +45,9 @@ var executeStep = function (executeStepRequest) {
   var parsedStepText = executeStepRequest.parsedStepText;
 
   var parameters = executeStepRequest.parameters.map(function (item) {
-    return item.value ? item.value : item.table;
+    return item.value ? item.value : new Table(item.table);
   });
+
   var step = stepRegistry.get(parsedStepText);
   new Test(step.fn, parameters, timeout).run().then(
     function (result) {

--- a/src/table.js
+++ b/src/table.js
@@ -1,27 +1,13 @@
-/**
-{
-  headers: {
-    cells: [ 'Product', 'Description' ]
-  },
-  rows: [
-    { cells: [ 'Gauge', 'Test automation with ease' ] },
-    { cells: [ 'Mingle', 'Agile project management' ] },
-    { cells: [ 'Snap', 'Hosted continuous integration' ] },
-    { cells: [ 'Gocd', 'Continuous delivery platform' ] }
-  ]
-}
-*/
+var Table = function (protoTable) {
+  Object.assign(this, protoTable);
 
-var Table = function(protoTable) {
-  this.protoTable = protoTable;
-
-  this.headers = protoTable.headers.cells.map(function(header) {
-    return header;
-  });
-
-  this.rows = protoTable.rows.map(function(row) {
-    return row.cells;
-  });
+  this.entries = function (callback) {
+    for (var row of this.rows) {
+      let entry = {};
+      row.cells.forEach((cell, index) => entry[this.headers.cells[index]] = cell);
+      callback(entry);
+    }
+  };
 };
 
 module.exports = Table;

--- a/test/table.js
+++ b/test/table.js
@@ -15,14 +15,32 @@ describe("ProtoTable parsing", function() {
     ]
   };
 
-  it("Should get headers", function() {
-    var table = new Table(protoTable);
-    expect(table.headers).to.deep.equal(["Product", "Description"]);
+  var table = new Table(protoTable);
+
+  it("Should get headers", function () {
+    expect(table.headers).to.deep.equal(protoTable.headers);
   });
 
-  it("Should get rows", function() {
-    var table = new Table(protoTable);
-    expect(table.rows[0]).to.deep.equal(["Gauge", "Test automation with ease"]);
+  it("Should get rows", function () {
+    expect(table.rows).to.deep.equal(protoTable.rows);
+  });
+
+  describe("Table entries", function () {
+
+    it("Should have correct number of entries", function () {
+      var result = [];
+      table.entries(entry => result.push(entry));
+      expect(result.length).to.equal(4);
+    });
+
+    it("Should have correct entry object", function () {
+      var result = [];
+      table.entries(entry => result.push(entry));
+      expect(result[1]).to.deep.equal({
+        "Product": "Mingle",
+        "Description": "Agile project management"
+      });
+    });
   });
 
 });


### PR DESCRIPTION
Fixes: #412 

Usage:

```
step("Almost all words have vowels <table>", function(table) {
  table.entries((entry) => {
    assert.equal(numberOfVowels(entry["Word"]), parseInt(entry["Vowel Count"]));
  });
});

step("Almost all words have vowels <table>", function(table) {
  table.entries((entry) => {
    const { Word } = entry;
  });
});

```

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>