### PR TITLE
fix: keep modname starts with `./`

### DIFF
--- a/js.json
+++ b/js.json
@@ -51,7 +51,7 @@
             "--init"
         ]
     },
-    "version": "2.3.16",
+    "version": "2.3.17",
     "gaugeVersionSupport": {
         "minimum": "1.0.7",
         "maximum": ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge-js",
-  "version": "2.3.16",
+  "version": "2.3.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge-js",
-  "version": "2.3.16",
+  "version": "2.3.17",
   "description": "JavaScript runner for Gauge",
   "main": "index.js",
   "scripts": {

--- a/src/req-manager.js
+++ b/src/req-manager.js
@@ -23,7 +23,7 @@ Req.prototype.load = function (modname) {
   }
 
   return (function (self, mod, modname) {
-    if (!modname.startsWith('./') && self.nativeModules.indexOf(modname) < 0) {
+    if (!modname.startsWith("./") && self.nativeModules.indexOf(modname) < 0) {
       modname = path.normalize(modname);
     }
     var m = new mod.Module(self.filepath, mod.Module);

--- a/src/req-manager.js
+++ b/src/req-manager.js
@@ -23,7 +23,7 @@ Req.prototype.load = function (modname) {
   }
 
   return (function (self, mod, modname) {
-    if (self.nativeModules.indexOf(modname) < 0) {
+    if (!modname.startsWith('./') && self.nativeModules.indexOf(modname) < 0) {
       modname = path.normalize(modname);
     }
     var m = new mod.Module(self.filepath, mod.Module);


### PR DESCRIPTION
Bug: `require('./constants')` resulted in `require('constants')`.