### PR TITLE
Remove unnecessary start call causing log noise

### DIFF
--- a/js.json
+++ b/js.json
@@ -51,7 +51,7 @@
             "--init"
         ]
     },
-    "version": "5.0.0",
+    "version": "5.0.1",
     "gaugeVersionSupport": {
         "minimum": "1.0.7",
         "maximum": ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gauge-js",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gauge-js",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge-js",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "type": "module",
   "engines": {
     "node": ">=18"

--- a/src/gauge.js
+++ b/src/gauge.js
@@ -53,7 +53,6 @@ function run() {
         (err, port) => {
           if (!err) {
             logger.info(`Listening on port:${port}`);
-            server.start();
           } else {
             logger.error(err);
             process.exit();


### PR DESCRIPTION
Fix these annoying logs from grpc-js every time gauge-js is used:

```
(node:1893) DeprecationWarning: Calling start() is no longer necessary. It can be safely omitted.
(Use `node --trace-deprecation ...` to show where the warning was created)
```