### PR TITLE
Bump version to 5.0.3 and fix CVE-2026-45740 by upgrading protobufjs to 8.2.0+

### DIFF
--- a/js.json
+++ b/js.json
@@ -51,7 +51,7 @@
             "--init"
         ]
     },
-    "version": "5.0.2",
+    "version": "5.0.3",
     "gaugeVersionSupport": {
         "minimum": "1.0.7",
         "maximum": ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gauge-js",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gauge-js",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
@@ -15,7 +15,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.3.0",
         "klaw-sync": "^7.0.0",
-        "protobufjs": "^8.0.3",
+        "protobufjs": "^8.2.0",
         "q": "^1.5.1"
       },
       "devDependencies": {
@@ -2614,14 +2614,13 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.3.tgz",
-      "integrity": "sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.4.0.tgz",
+      "integrity": "sha512-iriNhQ57SYA5Jbdi+41AyPdx6jPPkFO7DODzkOBmqFhgYn/JzX2HxgxYPY18eQAs3CP/AWqtPvkWn8rclRAxdQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge-js",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "type": "module",
   "engines": {
     "node": ">=18"
@@ -34,7 +34,7 @@
     "esprima": "^4.0.1",
     "estraverse": "^5.3.0",
     "klaw-sync": "^7.0.0",
-    "protobufjs": "^8.0.3",
+    "protobufjs": "^8.2.0",
     "q": "^1.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
**Fixed CVE-2026-45740 (High Severity)**

- Vulnerability: protobufjs 8.0.3 had CVE-2026-45740 (high severity)
- Fix: Upgraded protobufjs from ^8.0.3 to ^8.2.0
- Result: Installed protobufjs 8.2.0 
- Verification: this CVE no longer appears in npm audit ( Still there are some macho related ones are showing in npm audit)


**Bumped Package Version to 5.0.3**

- Updated package.json: 5.0.2 → 5.0.3
- Updated js.json: 5.0.2 → 5.0.3
- Updated package-lock.json: 5.0.2 → 5.0.3