### PR TITLE
Bump version to 5.0.6 to release CVE-2026-48068 fix

### DIFF
--- a/js.json
+++ b/js.json
@@ -54,7 +54,7 @@
             "--init"
         ]
     },
-    "version": "5.0.5",
+    "version": "5.0.6",
     "gaugeVersionSupport": {
         "minimum": "1.0.7",
         "maximum": ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gauge-js",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gauge-js",
-      "version": "5.0.5",
+      "version": "5.0.6",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge-js",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "type": "module",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
- Updated plugin version from 5.0.5 to 5.0.6
- Repository already has @grpc/grpc-js 1.14.4 which fixes CVE-2026-48068
- This version bump documents that the vulnerability is addressed
- CVE-2026-48068: high severity (CVSS 7.5) in @grpc/grpc-js <1.14.4